### PR TITLE
Add normative text to verification and processing section to verify public key

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -327,7 +327,7 @@ DID URL of the DID in the `iss` value, identifying the public key.
 - X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
 defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
 certificate chain in the following cases:
-    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. The DNS name MUST matche a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
+    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. The DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
     - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. The URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 
 Additional rules for verifying the public key belongs to the Issuer MAY be used but are

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -326,8 +326,8 @@ DID URL of the DID in the `iss` value, identifying the public key.
 `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
 certificate chain. In this case, additionally the `iss` value of the Issuer-signed JWT MUST be
     - a DNS name that matches a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of
-the leaf certificate,
-    - or a URN that matches a `unifiedResourceName` SAN entry of the leaf certificate.
+the leaf certificate, or
+    - a URN that matches a `unifiedResourceName` SAN entry of the leaf certificate.
 
 Other methods for verifying the public key belongs to the Issuer MAY be used but are
 out of scope of this specification.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -628,6 +628,7 @@ for their contributions (some of which substantial) to this draft and to the ini
 * Rename `type` to `vct`
 * Removed duplicated and inconsistent requirements on KB-JWT
 * Editorial changes
+* Added verification process to confirm the correspondence of the public key with issuer.
 
 -00
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -298,9 +298,8 @@ If Key Binding is required (refer to the security considerations in Section 9.6 
 according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
-Furthermore, the recipient of the SD-JWT VC MUST obtain the public key used for
-verification of the Issuer-signed JWT and verify the public key belongs to the
-Issuer of the Issuer-signed JWT, as defined in (#public-key-discovery-for-issuer-signed-jwts).
+Furthermore, the recipient of the SD-JWT VC MUST obtain the public verification key
+of the Issuer-signed JWT as defined (#public-key-discovery-for-issuer-signed-jwts).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.
@@ -314,7 +313,10 @@ Any claims used that are not understood MUST be ignored.
 Additional validation rules MAY apply, but their use is out of the scope of this
 specification.
 
-## Public Key Discovery for Issuer-signed JWTs {#public-key-discovery-for-issuer-signed-jwts}
+## Obtaining Public Key for Issuer-signed JWTs {#public-key-discovery-for-issuer-signed-jwts}
+
+A recipient of an SD-JWT VC MUST ensure that the public verification of the Issuer-signed JWT
+belongs to the Issuer of the Issuer-signed JWT.
 
 A recipient of an SD-JWT VC MUST apply the following rules to obtain the public
 verification key for the Issuer-signed JWT:

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -317,6 +317,7 @@ specification.
 
 A recipient of an SD-JWT VC MUST apply the following rules to obtain the public
 verification key for the Issuer-signed JWT:
+
 - JWT Issuer Metadata: If the `iss` value contains an HTTPS URI, the recipient MUST
 obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
 - DID Document Resolution: If the `iss` value contains a DID, the recipient MUST retrieve

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -327,7 +327,7 @@ DID URL of the DID in the `iss` value, identifying the public key.
 - X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
 defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
 certificate chain in the following cases:
-    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. The DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
+    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. In this case, the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
     - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. The URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 
 Additional rules for verifying the public key belongs to the Issuer MAY be used but are

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -506,9 +506,10 @@ as outlined in (#public-key-for-issuer-signed-jwts-verification), it is critical
 that those rules maintain the integrity of the relationship between the `iss` value
 within the Issuer-signed JWT and the public keys of the Issuer.
 
-In situations where an attacker tampers with an SD-JWT VC, it is paramount
-to ensure that they cannot exert influence over the verification process while
-employing the same `iss` value.
+It MUST be ensured that for any given `iss` value, an attacker cannot influence
+the type of verification process used. Otherwise, an attacker could attempt to make
+the Verifier use a verification process not intended by the Issuer, allowing the
+attacker to potentially manipulate the verification result to their advantage.
 
 # Privacy Considerations {#privacy-considerations}
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -318,7 +318,7 @@ specification.
 
 A recipient of the SD-JWT VC MUST apply the following rules to verify the
 Issuer-signed JWT corresponds to the Issuer:
-- JWT Issuer Metadata: If the `iss` value contains a HTTPS URI, the recipient MUST
+- JWT Issuer Metadata: If the `iss` value contains an HTTPS URI, the recipient MUST
 obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
 - DID Document Resolution: If the `iss` value contains a DID, the recipient MUST retrieve
 the public key from the DID Document resolved from the DID in the `iss` value.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -300,7 +300,7 @@ the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
 Furthermore, the recipient of the SD-JWT VC MUST verify that the public key used for
 verification of the Issuer-signed JWT belongs to the Issuer of the Issuer-signed JWT,
-as defined in (#public-key-for-issuer-signed-jwts-verification).
+as defined in (#public-key-discovery-for-issuer-signed-jwts-verification).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.
@@ -314,10 +314,10 @@ Any claims used that are not understood MUST be ignored.
 Additional validation rules MAY apply, but their use is out of the scope of this
 specification.
 
-## Public Key for Issuer-signed JWTs Verification {#public-key-for-issuer-signed-jwts-verification}
+## Public Key Discovery for Issuer-signed JWTs Verification {#public-key-discovery-for-issuer-signed-jwts-verification}
 
-A recipient of the SD-JWT VC MUST apply the following rules to verify the
-Issuer-signed JWT corresponds to the Issuer:
+A recipient of an SD-JWT VC MUST apply the following rules to obtain the public
+verification key for the Issuer-signed JWT:
 - JWT Issuer Metadata: If the `iss` value contains an HTTPS URI, the recipient MUST
 obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
 - DID Document Resolution: If the `iss` value contains a DID, the recipient MUST retrieve
@@ -502,7 +502,7 @@ Additional considerations can be found in [@OWASP_SSRF].
 ## Ecosystem-specific Public Key Verification Methods {#ecosystem-verification-rules}
 
 When defining ecosystem-specific rules for the verification of the public key,
-as outlined in (#public-key-for-issuer-signed-jwts-verification), it is critical
+as outlined in (#public-key-discovery-for-issuer-signed-jwts-verification), it is critical
 that those rules maintain the integrity of the relationship between the `iss` value
 within the Issuer-signed JWT and the public keys of the Issuer.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -298,8 +298,8 @@ If Key Binding is required (refer to the security considerations in Section 9.6 
 according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
-Furthermore, the recipient of the SD-JWT VC MUST verify the public key used to
-verify the Issuer-signed JWT corresponds to Issuer of the Issuer-signed JWT.
+Furthermore, the recipient of the SD-JWT VC MUST verify that the public key used for
+verification of the Issuer-signed JWT belongs to the Issuer of the Issuer-signed JWT.
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -328,7 +328,7 @@ DID URL of the DID in the `iss` value, identifying the public key.
 defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
 certificate chain in the following cases:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. In this case, the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
-    - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. The URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
+    - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. In this case, the URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 
 Additional rules for verifying the public key belongs to the Issuer MAY be used but are
 out of scope of this specification.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -321,7 +321,7 @@ verification key for the Issuer-signed JWT:
 obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
 - DID Document Resolution: If the `iss` value contains a DID, the recipient MUST retrieve
 the public key from the DID Document resolved from the DID in the `iss` value.
-If the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
+In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
 DID URL of the DID in the `iss` value, identifying the public key.
 - X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
 defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -638,7 +638,7 @@ for their contributions (some of which substantial) to this draft and to the ini
 * Rename `type` to `vct`
 * Removed duplicated and inconsistent requirements on KB-JWT
 * Editorial changes
-* Added verification process to confirm the correspondence of the public key with issuer.
+* Added issuer public verification key discovery section.
 
 -00
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -298,9 +298,9 @@ If Key Binding is required (refer to the security considerations in Section 9.6 
 according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
-Furthermore, the recipient of the SD-JWT VC MUST verify that the public key used for
-verification of the Issuer-signed JWT belongs to the Issuer of the Issuer-signed JWT,
-as defined in (#public-key-discovery-for-issuer-signed-jwts-verification).
+Furthermore, the recipient of the SD-JWT VC MUST obtain the public key used for
+verification of the Issuer-signed JWT and verify the public key belongs to the
+Issuer of the Issuer-signed JWT, as defined in (#public-key-discovery-for-issuer-signed-jwts).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.
@@ -314,7 +314,7 @@ Any claims used that are not understood MUST be ignored.
 Additional validation rules MAY apply, but their use is out of the scope of this
 specification.
 
-## Public Key Discovery for Issuer-signed JWTs Verification {#public-key-discovery-for-issuer-signed-jwts-verification}
+## Public Key Discovery for Issuer-signed JWTs {#public-key-discovery-for-issuer-signed-jwts}
 
 A recipient of an SD-JWT VC MUST apply the following rules to obtain the public
 verification key for the Issuer-signed JWT:
@@ -502,7 +502,7 @@ Additional considerations can be found in [@OWASP_SSRF].
 ## Ecosystem-specific Public Key Verification Methods {#ecosystem-verification-rules}
 
 When defining ecosystem-specific rules for the verification of the public key,
-as outlined in (#public-key-discovery-for-issuer-signed-jwts-verification), it is critical
+as outlined in (#public-key-discovery-for-issuer-signed-jwts), it is critical
 that those rules maintain the integrity of the relationship between the `iss` value
 within the Issuer-signed JWT and the public keys of the Issuer.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -330,7 +330,7 @@ the leaf certificate,
     - or a URN that matches a `unifiedResourceName` SAN entry of the leaf certificate.
 
 Other methods for verifying the public key belongs to the Issuer MAY be used but are
-out-of-scope of this specification.
+out of scope of this specification.
 
 # JWT Issuer Metadata {#jwt-issuer-metadata}
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -298,10 +298,9 @@ If Key Binding is required (refer to the security considerations in Section 9.6 
 according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
-For the verification, the `iss` claim in the SD-JWT MAY be used to retrieve the
-public key from the JWT Issuer Metadata configuration (as defined in
-(#jwt-issuer-metadata)) of the SD-JWT VC issuer. Alternative methods MAY be used
-to obtain the public key to verify the signature of the SD-JWT.
+Furthermore, the recipient of the SD-JWT VC MUST verify the public key used to
+verify the Issuer-signed JWT corresponds to Issuer of the Issuer-signed JWT, as
+defined in (#verifying-public-key-for-issuer-signed-jwts).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -503,7 +503,7 @@ Additional considerations can be found in [@OWASP_SSRF].
 ## Ecosystem-specific Public Key Verification Methods
 
 When defining ecosystem-specific rules for the verification of the public key,
-as outlined in (#verifying-public-key-for-issuer-signed-jwts), it is critical
+as outlined in (#public-key-for-issuer-signed-jwts-verification), it is critical
 that those rules maintain the integrity of the relationship between the `iss` value
 within the Issuer-signed JWT and the public keys of the Issuer.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -498,7 +498,7 @@ valid JWT Issuer Metadata configuration document before processing it.
 
 Additional considerations can be found in [@OWASP_SSRF].
 
-## Ecosystem-specific Public Key Verification Methods
+## Ecosystem-specific Public Key Verification Methods {#ecosystem-verification-rules}
 
 When defining ecosystem-specific rules for the verification of the public key,
 as outlined in (#public-key-for-issuer-signed-jwts-verification), it is critical

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -330,8 +330,7 @@ certificate chain in the following cases:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. In this case, the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
     - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. In this case, the URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 
-Additional rules for verifying the public key belongs to the Issuer MAY be used but are
-out of scope of this specification.
+Separate specifications or ecosystem regulations MAY define rules complementing the rules defined above, but such rules are out of scope of this specification. See (#ecosystem-verification-rules) for security considerations.
 
 # JWT Issuer Metadata {#jwt-issuer-metadata}
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -299,7 +299,8 @@ according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
 Furthermore, the recipient of the SD-JWT VC MUST verify that the public key used for
-verification of the Issuer-signed JWT belongs to the Issuer of the Issuer-signed JWT.
+verification of the Issuer-signed JWT belongs to the Issuer of the Issuer-signed JWT,
+as defined in (#verifying-public-key-for-issuer-signed-jwts).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -299,7 +299,7 @@ according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
 Furthermore, the recipient of the SD-JWT VC MUST obtain the public verification key
-of the Issuer-signed JWT as defined (#public-key-discovery-for-issuer-signed-jwts).
+for the Issuer-signed JWT as defined in (#public-key-discovery-for-issuer-signed-jwts).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -325,7 +325,7 @@ DID URL of the DID in the `iss` value, identifying the public key.
 - X.509 Certificates: Obtain the public key from the leaf X.509 certificate defined by the
 `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
 certificate chain. In this case, additionally the `iss` value of the Issuer-signed JWT MUST be
-    - a DNS name that matches a `dNSName` Subject Alternative Name (SAN) [RFC5280] entry of
+    - a DNS name that matches a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of
 the leaf certificate,
     - or a URN that matches a `unifiedResourceName` SAN entry of the leaf certificate.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -315,9 +315,6 @@ specification.
 
 ## Obtaining Public Key for Issuer-signed JWTs {#public-key-discovery-for-issuer-signed-jwts}
 
-A recipient of an SD-JWT VC MUST ensure that the public verification of the Issuer-signed JWT
-belongs to the Issuer of the Issuer-signed JWT.
-
 A recipient of an SD-JWT VC MUST apply the following rules to obtain the public
 verification key for the Issuer-signed JWT:
 - JWT Issuer Metadata: If the `iss` value contains an HTTPS URI, the recipient MUST

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -300,7 +300,7 @@ the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
 Furthermore, the recipient of the SD-JWT VC MUST verify that the public key used for
 verification of the Issuer-signed JWT belongs to the Issuer of the Issuer-signed JWT,
-as defined in (#verifying-public-key-for-issuer-signed-jwts).
+as defined in (#public-key-for-issuer-signed-jwts-verification).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.
@@ -314,23 +314,23 @@ Any claims used that are not understood MUST be ignored.
 Additional validation rules MAY apply, but their use is out of the scope of this
 specification.
 
-## Verifying Public Key for Issuer-signed JWTs {#verifying-public-key-for-issuer-signed-jwts}
+## Public Key for Issuer-signed JWTs Verification {#public-key-for-issuer-signed-jwts-verification}
 
-The following methods are RECOMMENDED to ensure the public key to verify the
+A recipient of the SD-JWT VC MUST apply the following rules to verify the
 Issuer-signed JWT corresponds to the Issuer:
-
-- JWT Issuer Metadata: Obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
-- DID Document Resolution: Retrieve the public key from the DID Document resolved from the DID in the `iss` value.
+- JWT Issuer Metadata: If the `iss` value contains a HTTPS URI, the recipient MUST
+obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
+- DID Document Resolution: If the `iss` value contains a DID, the recipient MUST retrieve
+the public key from the DID Document resolved from the DID in the `iss` value.
 If the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
 DID URL of the DID in the `iss` value, identifying the public key.
-- X.509 Certificates: Obtain the public key from the leaf X.509 certificate defined by the
-`x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
-certificate chain. In this case, additionally the `iss` value of the Issuer-signed JWT MUST be
-    - a DNS name that matches a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of
-the leaf certificate, or
-    - a URN that matches a `unifiedResourceName` SAN entry of the leaf certificate.
+- X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
+defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
+certificate chain in the following cases:
+    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. The DNS name MUST matche a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
+    - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. The URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 
-Other methods for verifying the public key belongs to the Issuer MAY be used but are
+Additional rules for verifying the public key belongs to the Issuer MAY be used but are
 out of scope of this specification.
 
 # JWT Issuer Metadata {#jwt-issuer-metadata}
@@ -500,6 +500,16 @@ valid JWT Issuer Metadata configuration document before processing it.
 
 Additional considerations can be found in [@OWASP_SSRF].
 
+## Ecosystem-specific Public Key Verification Methods
+
+When defining ecosystem-specific rules for the verification of the public key,
+as outlined in (#verifying-public-key-for-issuer-signed-jwts), it is critical
+that those rules maintain the integrity of the relationship between the `iss` value
+within the Issuer-signed JWT and the public keys of the Issuer.
+
+In situations where an attacker tampers with an SD-JWT VC, it is paramount
+to ensure that they cannot exert influence over the verification process while
+employing the same `iss` value.
 
 # Privacy Considerations {#privacy-considerations}
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -324,7 +324,9 @@ obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metad
 the public key from the DID Document resolved from the DID in the `iss` value.
 If the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
 DID URL of the DID in the `iss` value, identifying the public key.
-- X.509 Certificates: If the `x5c`, `x5c`, or `x5t` JWT header parameters are present, the recipient MUST obtain the public key from the leaf X.509 certificate defined by of the Issuer-signed JWT and validate the X.509 certificate chain in the following cases:
+- X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
+defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
+certificate chain in the following cases:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. The DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
     - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. The URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -324,9 +324,7 @@ obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metad
 the public key from the DID Document resolved from the DID in the `iss` value.
 If the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
 DID URL of the DID in the `iss` value, identifying the public key.
-- X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
-defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
-certificate chain in the following cases:
+- X.509 Certificates: If the `x5c`, `x5c`, or `x5t` JWT header parameters are present, the recipient MUST obtain the public key from the leaf X.509 certificate defined by of the Issuer-signed JWT and validate the X.509 certificate chain in the following cases:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. The DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
     - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. The URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -318,7 +318,7 @@ specification.
 The following methods are RECOMMENDED to ensure the public key to verify the
 Issuer-signed JWT corresponds to the Issuer:
 
-- Using JWT Issuer Metadata: Obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
+- JWT Issuer Metadata: Obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
 - DID Document Resolution: Retrieve the public key from the DID Document resolved from the DID in the `iss` value.
 If the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
 DID URL of the DID in the `iss` value, identifying the public key.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -299,8 +299,7 @@ according to Section 6 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
 Furthermore, the recipient of the SD-JWT VC MUST verify the public key used to
-verify the Issuer-signed JWT corresponds to Issuer of the Issuer-signed JWT, as
-defined in (#verifying-public-key-for-issuer-signed-jwts).
+verify the Issuer-signed JWT corresponds to Issuer of the Issuer-signed JWT.
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.
@@ -313,6 +312,25 @@ Any claims used that are not understood MUST be ignored.
 
 Additional validation rules MAY apply, but their use is out of the scope of this
 specification.
+
+## Verifying Public Key for Issuer-signed JWTs {#verifying-public-key-for-issuer-signed-jwts}
+
+The following methods are RECOMMENDED to ensure the public key to verify the
+Issuer-signed JWT corresponds to the Issuer:
+
+- Using JWT Issuer Metadata: Obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
+- DID Document Resolution: Retrieve the public key from the DID Document resolved from the DID in the `iss` value.
+If the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute
+DID URL of the DID in the `iss` value, identifying the public key.
+- X.509 Certificates: Obtain the public key from the leaf X.509 certificate defined by the
+`x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
+certificate chain. In this case, additionally the `iss` value of the Issuer-signed JWT MUST be
+    - a DNS name that matches a `dNSName` Subject Alternative Name (SAN) [RFC5280] entry of
+the leaf certificate,
+    - or a URN that matches a `unifiedResourceName` SAN entry of the leaf certificate.
+
+Other methods for verifying the public key belongs to the Issuer MAY be used but are
+out-of-scope of this specification.
 
 # JWT Issuer Metadata {#jwt-issuer-metadata}
 


### PR DESCRIPTION
This PR does the following:
- make verification that the public key of the Issuer-signed JWT belongs to the Issuer mandatory
- introduce methods to perform this verification based on JWT Issuer Metadata, X.509 Certificates and DIDs

Potentially fixes #168, #143. Partially #134 

Out-of-scope:
- Renaming and moving JWT Issuer Metadata Section