### PR TITLE
Fixed obtaining verification key rules

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -323,18 +323,16 @@ specification.
 
 ## Issuer-signed JWT Verification Key Validation {#issuer-signed-jwt-verification-key-validation}
 
-A recipient of an SD-JWT VC MUST apply the following rules to validate the public
+A recipient of an SD-JWT VC MUST apply the following rules to validate that the public
 verification key for the Issuer-signed JWT corresponds to the `iss` value:
 
-- JWT Issuer Metadata: If the `iss` value contains an HTTPS URI, the recipient MUST
+- JWT Issuer Metadata: If a recipient supports JWT Issuer Metadata and if the `iss` value contains an HTTPS URI, the recipient MUST
 obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
-- X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
-corresponding to the `x5c` JWT header parameter of the Issuer-signed JWT if the `x5c` JWT Header is present.
-In this case, the recipient MUST validate the X.509 certificate chain and validate the `iss` value as follows:
+- X.509 Certificates: If the recipient supports X.509 Certificates, the recipient MUST obtain the public key from the leaf X.509 certificate defined by the `x5c` JWT header parameters of the Issuer-signed JWT and validate the X.509
+certificate chain in the following cases:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501], the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
     - In all other cases, the `iss` value MUST match a `uniformResourceIdentifier` SAN entry of the leaf certificate.
-- DID Document Resolution: If the `iss` value contains a DID [@W3C.DID], the recipient MUST retrieve
-the public key from the DID Document resolved from the DID in the `iss` value. In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute DID URL of the DID in the `iss` value, identifying the public key.
+- DID Document Resolution: If a recipient supports DID Document Resolution and if the `iss` value contains a DID [@W3C.DID], the recipient MUST retrieve the public key from the DID Document resolved from the DID in the `iss` value. In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute DID URL of the DID in the `iss` value, identifying the public key.
 
 Separate specifications or ecosystem regulations MAY define rules complementing the rules defined above, but such rules are out of scope of this specification. See (#ecosystem-verification-rules) for security considerations.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -332,7 +332,7 @@ obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metad
 corresponding to the `x5c` JWT header parameter of the Issuer-signed JWT if the `x5c` JWT Header is present.
 In this case, the recipient MUST validate the X.509 certificate chain and validate the `iss` value as follows:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501], the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
-    - In all other cases, the `iss` value MUST match a `uniformResourceIdentifier` SAN entry of the leaf certificate.
+    - In all other cases, the `iss` value MUST match a `unifiedResourceIdentifier` SAN entry of the leaf certificate.
 - DID Document Resolution: If the `iss` value contains a DID [@W3C.DID], the recipient MUST retrieve
 the public key from the DID Document resolved from the DID in the `iss` value. In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute DID URL of the DID in the `iss` value, identifying the public key.
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -677,7 +677,6 @@ for their contributions (some of which substantial) to this draft and to the ini
 # Document History
 
 -02
-
 * Made specific rules for public verification key validation conditional
 * Finetuned rules for obtaining public verification key
 * Editorial changes

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -306,8 +306,8 @@ If Key Binding is required (refer to the security considerations in Section 11.6
 according to Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
-Furthermore, the recipient of the SD-JWT VC MUST obtain the public verification key
-for the Issuer-signed JWT as defined in (#public-key-discovery-for-issuer-signed-jwts).
+Furthermore, the recipient of the SD-JWT VC MUST validate that the public verification key
+for the Issuer-signed JWT as defined in (#issuer-signed-jwt-verification-key-validation).
 
 If there are no selectively disclosable claims, there is no need to process the
 `_sd` claim nor any Disclosures.
@@ -321,23 +321,22 @@ Any claims used that are not understood MUST be ignored.
 Additional validation rules MAY apply, but their use is out of the scope of this
 specification.
 
-## Obtaining Public Key for Issuer-signed JWTs {#public-key-discovery-for-issuer-signed-jwts}
+## Issuer-signed JWT Verification Key Validation {#issuer-signed-jwt-verification-key-validation}
 
-A recipient of an SD-JWT VC MUST apply the following rules to validate that the public
+A recipient of an SD-JWT VC MUST apply the following rules to validate the public
 verification key for the Issuer-signed JWT corresponds to the `iss` value:
 
-- JWT Issuer Metadata: If a recipient supports JWT Issuer Metadata and if the `iss` value contains an HTTPS URI, the recipient MUST
+- JWT Issuer Metadata: If the `iss` value contains an HTTPS URI, the recipient MUST
 obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metadata).
-- DID Document Resolution: If a recipient supports DID Document Resolution and if the `iss` value contains a DID [@W3C.DID], the recipient MUST retrieve the public key from the DID Document resolved from the DID in the `iss` value. In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute DID URL of the DID in the `iss` value, identifying the public key.
-- X.509 Certificates: If the recipient supports X.509 Certificates, the recipient MUST obtain the public key from the leaf X.509 certificate defined by the `x5c`, `x5c`, or `x5t` JWT header parameters of the Issuer-signed JWT and validate the X.509
-certificate chain in the following cases:
-    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501]. In this case, the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
-    - If the `iss` value contains a URN using the URN URI scheme [@RFC2141]. In this case, the URN MUST match a `unifiedResourceName` SAN entry of the leaf certificate.
+- X.509 Certificates: The recipient MUST obtain the public key from the leaf X.509 certificate
+corresponding to the `x5c` JWT header parameter of the Issuer-signed JWT if the `x5c` JWT Header is present.
+In this case, the recipient MUST validate the X.509 certificate chain and validate the `iss` value as follows:
+    - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501], the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
+    - In all other cases, the `iss` value MUST match a `uniformResourceIdentifier` SAN entry of the leaf certificate.
+- DID Document Resolution: If the `iss` value contains a DID [@W3C.DID], the recipient MUST retrieve
+the public key from the DID Document resolved from the DID in the `iss` value. In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute DID URL of the DID in the `iss` value, identifying the public key.
 
 Separate specifications or ecosystem regulations MAY define rules complementing the rules defined above, but such rules are out of scope of this specification. See (#ecosystem-verification-rules) for security considerations.
-
-If a recipient cannot validate that the public verification key corresponds to the `iss` value of the Issuer-signed JWT,
-the SD-JWT VC MUST be rejected.
 
 # JWT Issuer Metadata {#jwt-issuer-metadata}
 
@@ -509,7 +508,7 @@ Additional considerations can be found in [@OWASP_SSRF].
 ## Ecosystem-specific Public Key Verification Methods {#ecosystem-verification-rules}
 
 When defining ecosystem-specific rules for the verification of the public key,
-as outlined in (#public-key-discovery-for-issuer-signed-jwts), it is critical
+as outlined in (#issuer-signed-jwt-verification-key-validation), it is critical
 that those rules maintain the integrity of the relationship between the `iss` value
 within the Issuer-signed JWT and the public keys of the Issuer.
 
@@ -680,6 +679,8 @@ for their contributions (some of which substantial) to this draft and to the ini
 -02
 
 * Made specific rules for public verification key validation conditional
+* Finetuned rules for obtaining public verification key
+* Editorial changes
 
 -01
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -338,6 +338,9 @@ the public key from the DID Document resolved from the DID in the `iss` value. I
 
 Separate specifications or ecosystem regulations MAY define rules complementing the rules defined above, but such rules are out of scope of this specification. See (#ecosystem-verification-rules) for security considerations.
 
+If a recipient cannot validate that the public verification key corresponds to the `iss` value of the Issuer-signed JWT,
+the SD-JWT VC MUST be rejected.
+
 # JWT Issuer Metadata {#jwt-issuer-metadata}
 
 This specification defines the JWT Issuer Metadata to retrieve the JWT Issuer

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -306,7 +306,11 @@ If Key Binding is required (refer to the security considerations in Section 11.6
 according to Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
+<<<<<<< HEAD
 Furthermore, the recipient of the SD-JWT VC MUST validate that the public verification key
+=======
+Furthermore, the recipient of the SD-JWT VC MUST validate the public verification key
+>>>>>>> f6d1a90 (fix: renamed obtaining public key for issuer-signed jwts section to Issuer-signed JWT verification key validation; fixing #185)
 for the Issuer-signed JWT as defined in (#issuer-signed-jwt-verification-key-validation).
 
 If there are no selectively disclosable claims, there is no need to process the

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -306,11 +306,7 @@ If Key Binding is required (refer to the security considerations in Section 11.6
 according to Section 8 of [@!I-D.ietf-oauth-selective-disclosure-jwt]. To verify
 the Key Binding JWT, the `cnf` claim of the SD-JWT MUST be used.
 
-<<<<<<< HEAD
 Furthermore, the recipient of the SD-JWT VC MUST validate that the public verification key
-=======
-Furthermore, the recipient of the SD-JWT VC MUST validate the public verification key
->>>>>>> f6d1a90 (fix: renamed obtaining public key for issuer-signed jwts section to Issuer-signed JWT verification key validation; fixing #185)
 for the Issuer-signed JWT as defined in (#issuer-signed-jwt-verification-key-validation).
 
 If there are no selectively disclosable claims, there is no need to process the

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -332,7 +332,7 @@ obtain the public key using JWT Issuer Metadata as defined in (#jwt-issuer-metad
 corresponding to the `x5c` JWT header parameter of the Issuer-signed JWT if the `x5c` JWT Header is present.
 In this case, the recipient MUST validate the X.509 certificate chain and validate the `iss` value as follows:
     - If the `iss` value contains a DNS name encoded as a URI using the DNS URI scheme [@RFC4501], the DNS name MUST match a `dNSName` Subject Alternative Name (SAN) [@RFC5280] entry of the leaf certificate.
-    - In all other cases, the `iss` value MUST match a `unifiedResourceIdentifier` SAN entry of the leaf certificate.
+    - In all other cases, the `iss` value MUST match a `uniformResourceIdentifier` SAN entry of the leaf certificate.
 - DID Document Resolution: If the `iss` value contains a DID [@W3C.DID], the recipient MUST retrieve
 the public key from the DID Document resolved from the DID in the `iss` value. In this case, if the `kid` JWT header parameter is present, the `kid` MUST be a relative or absolute DID URL of the DID in the `iss` value, identifying the public key.
 


### PR DESCRIPTION
This PR introduces the following changes:
- Fixes #182
- Fixes #185
- Fixed `uniformResourceIdentifier` SAN Extension rule
- Removed all options for X509 except `x5c`
