### PR TITLE
Switch back to the main sd-jwt-python library branch

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -30,7 +30,7 @@ jobs:
     - name: "Install SD-JWT tooling"
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git@danielfett/add-header-modifications
+        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git
 
     # Build the local examples
     - name: "Build local examples"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,7 +25,7 @@ jobs:
     - name: "Install SD-JWT tooling"
       run: |
         python3 -m pip install --upgrade pip
-        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git@danielfett/add-header-modifications
+        python3 -m pip install git+https://github.com/openwallet-foundation-labs/sd-jwt-python.git
 
     # Build the local examples
     - name: "Build local examples"


### PR DESCRIPTION
Switch back to the main branch of the sd-jwt-python library for example generation.

To fix #206 where `sd_hash` was missing from the Key Binding JWT in the example. 

https://drafts.oauth.net/oauth-sd-jwt-vc/206_sd_hash/draft-ietf-oauth-sd-jwt-vc.html#section-4.2-2 has the PR preview of the fix 