### PR TITLE
Include disclosure of age_equal_or_over/18 in the PID example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ draft-ietf-oauth-sd-jwt-vc.xml
 package-lock.json
 report.xml
 !requirements.txt
+
+# Ignore output of examples except for specification.yml
+examples/*/*
+!examples/*/specification.yml

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -754,7 +754,7 @@ The following Disclosures are created by the Issuer:
 
 {{examples/03-pid/disclosures.md}}
 
-The following shows a presentation of the SD-JWT with a Key Binding JWT that discloses only the nationality of the Holder:
+The following shows a presentation of the SD-JWT with a Key Binding JWT that discloses only nationality and the fact that the person is over 18 years old:
 
 <{{examples/03-pid/sd_jwt_presentation.txt}}
 
@@ -783,6 +783,10 @@ Kristina Yasuda
 for their contributions (some of which substantial) to this draft and to the initial set of implementations.
 
 # Document History
+
+-03
+
+*  Include disclosure of age_equal_or_over/18 in the PID example
 
 -02
 

--- a/examples/03-pid/specification.yml
+++ b/examples/03-pid/specification.yml
@@ -19,19 +19,19 @@ user_claims:
     country: DE
   !sd also_known_as: Schwester Agnes
   age_equal_or_over:
-    !sd '12': true
-    !sd '14': true
-    !sd '16': true
-    !sd '18': true
-    !sd '21': true
-    !sd '65': false
+    !sd "12": true
+    !sd "14": true
+    !sd "16": true
+    !sd "18": true
+    !sd "21": true
+    !sd "65": false
 
 
 holder_disclosed_claims:
   nationalities:
     - true
-  #age_equal_or_over:
-  #  '18': true
+  age_equal_or_over:
+    "18": true
 
 add_decoy_claims: false
 key_binding: true


### PR DESCRIPTION
Related to https://github.com/oauth-wg/oauth-selective-disclosure-jwt/pull/411 disclosure of age_equal_or_over/18 in the example wasn't working quite right and so was pulled out right before publication of -02 in #214. This PR puts disclosure of age_equal_or_over/18 back in the example. 

See it starting here:
https://drafts.oauth.net/oauth-sd-jwt-vc/pid_example_disclose_age_over_18/draft-ietf-oauth-sd-jwt-vc.html#appendix-B.1-52 
