### PR TITLE
Set upload email in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 LIBDIR := lib
 include $(LIBDIR)/main.mk
 
+export UPLOAD_EMAIL ?= bcampbell@pingidentity.com
+
 $(LIBDIR)/main.mk:
 ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule sync


### PR DESCRIPTION
attempt to avoid future failures uploading to the IETF datatracker due to scrobbling the wrong email 

see:
https://github.com/martinthomson/i-d-template/commit/638eeb4a9d39ed632176c3b0645b3e0ee59962b0#diff-008e429a10bb721eeba15490213909aebf09cda078e9942e524df5bd5837fc54R81-R86


was seeing:
```
Run martinthomson/i-d-template@v1
/usr/bin/docker run --name ghcriomartinthomsonidtemplateactionlatest_49ecb8 --label f5dd11 --workdir /github/workspace --rm -e "INPUT_MAKE" -e "INPUT_TOKEN" -e "GITHUB_TOKEN" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/oauth-sd-jwt-vc/oauth-sd-jwt-vc":"/github/workspace" ghcr.io/martinthomson/i-d-template-action:latest  "upload"
warning: lib/default-branch.py: correcting the default branch locally:
warning: lib/default-branch.py:     git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
make: '.targets.mk' is up to date.
warning: lib/default-branch.py: correcting the default branch locally:
warning: lib/default-branch.py:     git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
git show "draft-ietf-oauth-sd-jwt-vc-05:draft-ietf-oauth-sd-jwt-vc.md" | sed -e 's/draft-ietf-oauth-sd-jwt-vc-latest/draft-ietf-oauth-sd-jwt-vc-05/g' >versioned/draft-ietf-oauth-sd-jwt-vc-05.md
cat versioned/draft-ietf-oauth-sd-jwt-vc-05.md  | mmark | lib/trace.sh versioned/draft-ietf-oauth-sd-jwt-vc-05.xml -s venue python3 lib/add-note.py | lib/trace.sh versioned/draft-ietf-oauth-sd-jwt-vc-05.xml -s v2v3 xml2rfc -q --rfc-base-url https://www.rfc-editor.org/rfc/ --id-base-url https://datatracker.ietf.org/doc/html/ --cache=/github/workspace/.refcache --v2v3 /dev/stdin -o /dev/stdout >versioned/draft-ietf-oauth-sd-jwt-vc-05.xml
rm versioned/draft-ietf-oauth-sd-jwt-vc-05.md
set -ex; tag="draft-ietf-oauth-sd-jwt-vc-05"; \
email="$(lib/get-email.sh "$tag" "versioned/draft-ietf-oauth-sd-jwt-vc-05.xml")"; \
[ -z "$email" ] && exit 1; \
replaces() { \
  [ "${1##*-}" = "00" ] || return; \
  file="$(git ls-files "${1%-[0-9][0-9]}.*")"; \
  for last in $(git log --follow --name-only --format=format: -- "${file%-[0-9][0-9]}" | sed -e '/^$/d' | grep -v draft-todo-yourname-protocol | cut -f 2 | uniq | tail +2); do \
    if [ -n "$(git tag -l "${last%.*}")" ]; then \
      echo -F; echo "replaces=${last%.*}"; break; \
    fi; \
  done; \
}; \
lib/trace.sh versioned/draft-ietf-oauth-sd-jwt-vc-05.xml -s upload-request curl -sS -D "versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload" \
    -F "user=$email" -F "xml=@versioned/draft-ietf-oauth-sd-jwt-vc-05.xml" $(replaces "$tag") \
    "https://datatracker.ietf.org/api/submission" && echo && \
  (head -1 "versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload" | grep -q '^HTTP/\S\S* 20[01]\b' || lib/trace.sh versioned/draft-ietf-oauth-sd-jwt-vc-05.xml -s upload-result ! cat "versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload" 1>&2)
+ tag=draft-ietf-oauth-sd-jwt-vc-05
++ lib/get-email.sh draft-ietf-oauth-sd-jwt-vc-05 versioned/draft-ietf-oauth-sd-jwt-vc-05.xml
+ email=fett@danielfett.de
+ '[' -z fett@danielfett.de ']'
++ replaces draft-ietf-oauth-sd-jwt-vc-05
++ '[' 05 = 00 ']'
++ return
+ lib/trace.sh versioned/draft-ietf-oauth-sd-jwt-vc-05.xml -s upload-request curl -sS -D versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload -F user=fett@danielfett.de -F xml=@versioned/draft-ietf-oauth-sd-jwt-vc-05.xml https://datatracker.ietf.org/api/submission
+ echo
{"error": "No person with username fett@danielfett.de"}
+ head -1 versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload
+ grep -q '^HTTP/\S\S* 20[01]\b'
+ lib/trace.sh versioned/draft-ietf-oauth-sd-jwt-vc-05.xml -s upload-result '!' cat versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload
HTTP/2 400 
date: Wed, 18 Sep 2024 18:10:56 GMT
content-type: application/json
content-length: 55
cross-origin-opener-policy: unsafe-none
referrer-policy: strict-origin-when-cross-origin
strict-transport-security: max-age=3600; includeSubDomains
vary: Cookie, origin
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
cf-cache-status: DYNAMIC
server: cloudflare
cf-ray: 8c534bad5c667ac2-SJC
alt-svc: h3=":443"; ma=86400

make[2]: *** [lib/upload.mk:27: versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload] Error 1
make[2]: *** Deleting file 'versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload'
make[1]: *** [lib/upload.mk:47: versioned/.draft-ietf-oauth-sd-jwt-vc-05.upload] Error 2
make: *** [lib/upload.mk:22: upload] Error 2
0s
0s
0s
```