### PR TITLE
change media type from `vc+sd-jwt` to `dc+sd-jwt`

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -162,7 +162,10 @@ This section defines encoding, validation and processing rules for SD-JWT VCs.
 ## Media Type
 
 SD-JWT VCs compliant with this specification MUST use the media type
-`application/vc+sd-jwt` as defined in (#application-vc-sd-jwt).
+`application/dc+sd-jwt` as defined in (#media-type).
+
+The base subtype name `dc` is meant to stand for "digital credential", which is
+a term that is emerging as a conceptual synonym for "verifiable credential".
 
 ## Data Format
 
@@ -179,7 +182,7 @@ This section defines JWT header parameters for the SD-JWT component of the
 SD-JWT VC.
 
 The `typ` header parameter of the SD-JWT MUST be present. The `typ` value MUST
-use `vc+sd-jwt`. This indicates that the payload of the SD-JWT contains plain
+use `dc+sd-jwt`. This indicates that the payload of the SD-JWT contains plain
 JSON and follows the rules as defined in this specification. It further
 indicates that the SD-JWT is a SD-JWT component of a SD-JWT VC.
 
@@ -188,9 +191,11 @@ The following is a non-normative example of a decoded SD-JWT header:
 ```
 {
   "alg": "ES256",
-  "typ": "vc+sd-jwt"
+  "typ": "dc+sd-jwt"
 }
 ```
+
+Note that this draft used `vc+sd-jwt` as the value of the `typ` header from its inception in July 2023 until November 2024 when it was changed to `dc+sd-jwt` to avoid conflict with the `vc` media type name registered by the W3C's Verifiable Credentials Data Model draft. In order to facilitate a minimally disruptive transition, it is RECOMMENDED that Verifiers and Holders accept both `vc+sd-jwt` and `dc+sd-jwt` as the value of the `typ` header for a reasonable transitional period.
 
 ### JWT Claims Set
 
@@ -1321,21 +1326,21 @@ recommendations in (#robust-retrieval) apply.
 - Claim Name: "vct"
 - Claim Description: Verifiable credential type identifier
 - Change Controller: IETF
-- Specification Document(s): [[ (#type-claim) of this of this specification ]]
+- Specification Document(s): [[ (#type-claim) of this specification ]]
 
 - Claim Name: "vct#integrity"
 - Claim Description: SD-JWT VC vct claim "integrity metadata" value
 - Change Controller: IETF
-- Specification Document(s): [[ (#document-integrity) of this of this specification ]]
+- Specification Document(s): [[ (#document-integrity) of this specification ]]
 
 ## Media Types Registry
 
-### application/vc+sd-jwt {#application-vc-sd-jwt}
+### application/dc+sd-jwt {#media-type}
 
-The Internet media type for a SD-JWT VC is `application/vc+sd-jwt`.
+The Internet media type for an SD-JWT VC is `application/dc+sd-jwt`.
 
 * Type name: `application`
-* Subtype name: `vc+sd-jwt`
+* Subtype name: `dc+sd-jwt`
 * Required parameters: n/a
 * Optional parameters: n/a
 * Encoding considerations: 8-bit code points; SD-JWT VC values are encoded as a series of base64url-encoded values (some of which may be the empty string) separated by period ('.') and tilde ('~') characters.
@@ -1563,6 +1568,10 @@ Kristina Yasuda
 for their contributions (some of which substantial) to this draft and to the initial set of implementations.
 
 # Document History
+
+-06
+
+* Update the anticipated media type registration request from `application/vc+sd-jwt` to `application/dc+sd-jwt`
 
 -05
 

--- a/examples/01/specification.yml
+++ b/examples/01/specification.yml
@@ -22,4 +22,4 @@ key_binding: true
 
 extra_header_parameters:
   kid: doc-signer-05-25-2022
-  typ: "vc+sd-jwt"
+  typ: "dc+sd-jwt"

--- a/examples/02/specification.yml
+++ b/examples/02/specification.yml
@@ -23,4 +23,4 @@ holder_disclosed_claims:
 key_binding: false
 
 extra_header_parameters:
-  typ: "vc+sd-jwt"
+  typ: "dc+sd-jwt"

--- a/examples/03-pid/specification.yml
+++ b/examples/03-pid/specification.yml
@@ -37,4 +37,4 @@ add_decoy_claims: false
 key_binding: true
 
 extra_header_parameters:
-  typ: "vc+sd-jwt"
+  typ: "dc+sd-jwt"


### PR DESCRIPTION
Update the anticipated media type registration request from `application/vc+sd-jwt` to `application/dc+sd-jwt` per the Dublin Accord (last slide of https://datatracker.ietf.org/meeting/121/materials/slides-121-oauth-sessb-sd-jwt-and-sd-jwt-vc-02) 