### PR TITLE
denial-of-service is a compound adjective and should be hyphenated when used to modify attacks

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -1081,7 +1081,7 @@ credential.
 In (#retrieving-type-metadata), various methods for distributing and retrieving
 metadata are described. Methods relying on a network connection may fail due to
 network issues or unavailability of a network connection due to offline usage of
-credentials, temporary server outages, or denial of service attacks on the
+credentials, temporary server outages, or denial-of-service attacks on the
 metadata server.
 
 Consumers SHOULD therefore implement a local cache as described in


### PR DESCRIPTION
"denial-of-service" is a compound adjective and should be hyphenated when used to modify "attacks."

also I wanted a simple new PR to see if it breaks the build too 