### PR TITLE
fix: update logo and background structure

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -1738,6 +1738,7 @@ Lukas J Han,
 Leif Johansson,
 Michael B. Jones,
 Mike Prorock,
+Mirko Mollik,
 Orie Steele,
 Paul Bastian,
 Pavel Zarecky,
@@ -1752,6 +1753,7 @@ for their contributions (some of which substantial) to this draft and to the ini
 
 -11
 
+* Add background image support to simple rendering method, update logo support to align with new background image approach.
 * Fixed an inconsistency to the description of `display` attribute of claim metadata.
 * Editorial updates and fixes.
 


### PR DESCRIPTION
fixes #305

- adds information for background image
- using the reference to apple guidelines, allowing a more granual approach (different images for multiple dimensions, etc)
- also aligning existing logo approach so both cases are using the same approach

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>