### PR TITLE
Set vct:integrity to the list of attribute to not selectively disclosed

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -598,7 +598,7 @@ The Type Metadata is retrieved using the HTTP GET method. The response MUST be a
 object as defined in (#type-metadata-format).
 
 If the claim `vct#integrity` is present in the SD-JWT VC, its value
-`vct#integrity` MUST be an "integrity metadata" string as defined in Section (#document-integrity). The claim MUST NOT be present if the `vct` claim is not set.
+`vct#integrity` MUST be an "integrity metadata" string as defined in Section (#document-integrity).
 
 ### From a Registry {#retrieval-from-registry}
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -250,7 +250,7 @@ information.
     * REQUIRED. The type of the Verifiable Credential, e.g.,
 `https://credentials.example.com/identity_credential`, as defined in (#type-claim).
 * `vct#integrity`
-    * OPTIONAL. The hash of the Type Metadata document to provide integrity as defined in Section (#document-integrity).
+    * OPTIONAL. The hash of the Type Metadata document to provide integrity as defined in (#document-integrity).
 * `status`
     * OPTIONAL. The information on how to read the status of the Verifiable
 Credential. See [@!I-D.ietf-oauth-status-list]

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -249,6 +249,8 @@ information.
 * `vct`
     * REQUIRED. The type of the Verifiable Credential, e.g.,
 `https://credentials.example.com/identity_credential`, as defined in (#type-claim).
+* `vct#integrity`
+    * OPTIONAL hash of the Type Metadata document to guarantee integrity as defined in Section (#document-integrity). MUST NOT be set if the `vct` claim is not set.
 * `status`
     * OPTIONAL. The information on how to read the status of the Verifiable
 Credential. See [@!I-D.ietf-oauth-status-list]
@@ -596,7 +598,7 @@ The Type Metadata is retrieved using the HTTP GET method. The response MUST be a
 object as defined in (#type-metadata-format).
 
 If the claim `vct#integrity` is present in the SD-JWT VC, its value
-`vct#integrity` MUST be an "integrity metadata" string as defined in Section (#document-integrity).
+`vct#integrity` MUST be an "integrity metadata" string as defined in Section (#document-integrity). The claim MUST NOT be present if the `vct` claim is not set.
 
 ### From a Registry {#retrieval-from-registry}
 

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -1540,6 +1540,7 @@ for their contributions (some of which substantial) to this draft and to the ini
 -11
 
 * Fixed an inconsistency to the description of `display` attribute of claim metadata.
+* add `vct#integrity` to the list of claims that cannot be selectively disclosed
 * Drop explicit treatment of the glue type metadata document concept
 * Editorial updates and fixes.
 * State that when the `status` claim is present and using the `status_list` mechanism, the associated Status List Token has to be a JWT.

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -250,7 +250,7 @@ information.
     * REQUIRED. The type of the Verifiable Credential, e.g.,
 `https://credentials.example.com/identity_credential`, as defined in (#type-claim).
 * `vct#integrity`
-    * OPTIONAL hash of the Type Metadata document to guarantee integrity as defined in Section (#document-integrity). MUST NOT be set if the `vct` claim is not set.
+    * OPTIONAL hash of the Type Metadata document to guarantee integrity as defined in Section (#document-integrity).
 * `status`
     * OPTIONAL. The information on how to read the status of the Verifiable
 Credential. See [@!I-D.ietf-oauth-status-list]

--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -250,7 +250,7 @@ information.
     * REQUIRED. The type of the Verifiable Credential, e.g.,
 `https://credentials.example.com/identity_credential`, as defined in (#type-claim).
 * `vct#integrity`
-    * OPTIONAL hash of the Type Metadata document to guarantee integrity as defined in Section (#document-integrity).
+    * OPTIONAL. The hash of the Type Metadata document to provide integrity as defined in Section (#document-integrity).
 * `status`
     * OPTIONAL. The information on how to read the status of the Verifiable
 Credential. See [@!I-D.ietf-oauth-status-list]


### PR DESCRIPTION
fixes #258

When reading the sentence of the chapter:

> The following registered JWT claims are used within the SD-JWT component of the SD-JWT VC and MUST NOT be included in the Disclosures, i.e., cannot be selectively disclosed:

I had two thoughts:
- these claims can not be disclosed -> hidden
- these claims are always disclosed -> visible

I suggest to clarify this here by something like saying

> cannot be selectifly disclosed and are always visible

Or is this clear becaue there is no option to hide an attribute (just visible to the holder, but that can never be disclosed like an embedded secret)

Signed-off-by: Mirko Mollik <mirko.mollik@eudi.sprind.org>