### PR TITLE
Updated svg_template to match pluralised appendix example

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -1642,6 +1642,7 @@ for their contributions (some of which substantial) to this draft and to the ini
 
 -13
 
+* Updated svg_template to match pluralised appendix example
 
 -12
 


### PR DESCRIPTION
Fixes #374
Fix discrepancy between svg_template rendering method and Appendix example which uses pluralised form.
Clarified wording for svg_templates MUST contain to avoid ambiguity on the definition of 'the object'