### PR TITLE
Address Dan's review

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -181,8 +181,6 @@ claims, and therefore the encoded SD-JWT will not contain any Disclosures.
 
 A presentation of an SD-JWT VC MUST be encoded as an SD-JWT or as an SD-JWT+KB defined in Section 4 or Section 8 of [@!RFC9901]. By default, the format defined in Section 4 of [@!RFC9901] is used, whereas support for the JWS JSON Serialization in Section 8 of [@!RFC9901] is OPTIONAL.
 
-The KB-JWT MAY include additional claims which, when not understood, the Verifier MUST ignore.
-
 ### JOSE Header
 
 This section defines JWT header parameters for the SD-JWT component of the


### PR DESCRIPTION
## Dan’s review comments — status & resolution

fixes #382 

preview here https://drafts.oauth.net/oauth-sd-jwt-vc/awoie/fix-dans-comments/draft-ietf-oauth-sd-jwt-vc.html

### General / Substantive

- [x] *"Need to update references from ietf-oauth-selective-disclosure-jwt to RFC 9901"*
  **OT:** All references were updated.

- [x] *“Since one explicit aim of the type metadata is versioning … does it make sense to put a v1 somewhere in the URI?”*  
  DF: I put a `/v1` in the Betelgeuse example.

- [x] **Inconsistent terminology: “Consumer” vs “consuming application”**  
  **OT:** Accepted. Terminology aligned to consistently use “Consumer”.

### Section 1.1

- [x] **Paragraph on verifier authenticity checks and key binding is long and confusing**
  **OT:** Accepted. Split into two sentences; already fixed by Brian in a previous PR.

- [x] **Note about not using W3C Verifiable Credentials Data Model seems out of place**  
  **OT:** Accepted. Moved to Related Standards section (Section 12).

### Section 1.4

- [x] **Definition of Consumer has singular/plural mismatch**  
  **OT:** Accepted. Definition clarified.

### Section 3.2

- [x] **Sections 3.2 and 4.1 appear duplicative**  
  **OT:** Accepted. Will merge section 4 into section 3 (incl. the presentation example), and also remove all normative text that just repeats SD-JWT.

### Section 3.4

- [x] **Incorrect reference to point 2.3 of Section 7.1 of SD-JWT**  
  **OT:** Accepted. Correct reference is point **2.c**.

- [x] *"I don't see a section 2.3 in the referenced doc."*
  **OT:** Root cause resolved by correcting the reference to 2.c.

### Section 5.1

- [x] *"Is there a reason to not follow the OIDC pattern of having the tenant or any other path before the .well-known/jwt-vc-issuer string?"*
  **OT:** Rejected. Won't fix. Intentional design. SD-JWT VC follows RFC 8414 host-bound `.well-known` semantics. OIDC intentionally deviates from the well-known specification; SD-JWT VC does not and uses the same approach as OAuth in [RFC8414](https://www.rfc-editor.org/rfc/rfc8414.html#section-3.1).

### Section 5.2

- [x] **Missing word “status” in “200 OK HTTP”**  
  **OT:** Fixed in -13.

- [x] **Error responses should use MUST for HTTP status codes**  
  **DF:** Propose to accept and also to add the same rule for type metadata.

- [x] **Confusing reference to “JWT” in `kid` recommendation**  
  **OT:** Accepted. Clarified to “Issuer-signed JWT”.

- [x] **Issuer value in example does not match `iss` value elsewhere**  
  **BC:** they don't need to match 

### Section 6.2

- [x] **Unclear whether `extends#integrity` must be listed explicitly**  
  DF: Fixed.

### Section 6.3

- [x] **Do we need to reference RFC 5890 / 3987 for URL comparison?**  
  **OT:** Rejected. No need for these references since comparing `vct` values is a string comparison.

### Section 6.3.1

- [x] **Typo: “Section Section 7.”**  
  **OT:** Accepted. Fixed.

### Section 7

- [x] **Incorrect SRI reference to Section 3.3.5**  
  **OT:** Accepted. We need to correct the reference of the SRI specification.
  **BC:** https://github.com/oauth-wg/oauth-sd-jwt-vc/commit/0f7fce57a53a1ed5244bba14bc4627e2a4d0fa07 should have fixed that

- [x] **Integrity verification marked MUST while integrity claim is optional**  
  > You say:
  > "A Consumer of the respective documents MUST verify the integrity ...
  > 
  > but the required claim is marked as optional in 3.2.2.2. Found that
  > confusing. Assume that means that if the X#integrity claim is present you
  > must verify the integrity? Maybe change to
  > 
  > When the corresponding integrity claim is present, a Consumer of the
  > respective documents MUST verify the integrity of the retrieved document as
  > defined ...

  DF: This was the originally intended meaning, I'll clarify.

### Section 8.2

- [x] **Display claim treated differently from other metadata**  
  > Why is the display claim treated differently in terms of overriding an
  > extension than any other metadata? any reason to call that out? The general
  > overriding process is mentioned in section 9.5, maybe remove 8.2.

  DF: This is intentional, I'll add a note to the document.

### Section 9

- [x] **Claims defined without `svg_id` — unclear use case** 
  > why would you have a claim defined without an svg_id? what is the use case?
  > 
  > if you are using a simple rendering method, no claims are displayed. Is
  > this future proofing, in case there's another render method added that
  > isn't an svg? in that case, maybe change it to claim_id so a future method
  > could reference the claim for display? then make it required? Or am I
  > missing some other reason for the claims to be defined in the type metadata?

  DF: I like the idea of renaming this `claim_id`. I don't think we should make it mandatory though. There are cases where you just don't need this.
  OT: Rejected. This would be a normative change without a huge upside. Note that some ETSI specs are referencing SD-JWT VC already.

### Section 9.1

- [x] **Why define new JSON path framework instead of JSON Pointer / JSONPath?**  
  > why not use jsonpath or jsonpointer (rfc6901) instead of defining a new
  > JSON path processing framework? I guess I worry whenever I see another path
  > processing algorithm defined.
  > 
  > But maybe I'm missing the reason not to use a more general purpose solution?

  **OT:** Rejected. Intentional design decision and justified in section 9.1.2 already.

### Section 10.6

- [x] **Prefix “Recommendation:” is unusual**  
  > Having the prefix *Recommendation:* is kinda weird and not common. maybe
  > strike, not sure it adds anything.

  **OT:** Accepted. Removed prefix.

### Section 10.7

- [x] **Introduces term “publisher” not used elsewhere**  
  > Introduces the term "publisher" which is not used anywhere else in the doc.
  > Maybe use issuer?

  **OT:** Accepted. However, publisher is different from the issuer. Terminology was added for publisher.
