### PR TITLE
Type Metadata identity: attempt to clarify value checking on retrieval of Type Metadata

### DIFF
--- a/draft-ietf-oauth-sd-jwt-vc.md
+++ b/draft-ietf-oauth-sd-jwt-vc.md
@@ -713,9 +713,9 @@ An example of a Type Metadata document is shown in (#ExampleTypeMetadata).
 ## Retrieving Type Metadata {#retrieving-type-metadata}
 
 A Consumer retrieving Type Metadata MUST ensure that the `vct` value in the
-SD-JWT VC payload is identical to the `vct` value in the reference to the Type
-Metadata (either in the SD-JWT VC itself or in an `extends` property in a Type
-Metadata document).
+retrieved document is identical to the reference used to retrieve it. For
+the initial document, that reference is the SD-JWT VC's `vct` claim value. For a
+parent document, that reference is the immediate child's `extends` property value.
 
 If the claim `vct#integrity` is present in the SD-JWT VC, its value
 MUST be an "integrity metadata" string as defined in (#document-integrity).
@@ -1949,6 +1949,7 @@ for their contributions (some of which substantial) to this draft and to the ini
 -20
 
 * Fix a couple of example hash values
+* Type Metadata identity: attempt to clarify value checking on retrieval of Type Metadata
 
 -19
 


### PR DESCRIPTION

    On the remaining points:

    1. Type Metadata identity

    Your reading matches the interpretation I was trying to express. My
    concern is specifically that the current sentence names the vct value in the
    SD-JWT VC payload and the vct value in the reference as its two operands. In
    the recursive case, those are C and P. It does not name the vct property in the
    document returned for reference P.

    If Daniel confirms the intended processing, wording along these lines would
    resolve my concern:

    For each retrieved Type Metadata document, the Consumer ensures that the vct
    value in that document is identical to the reference used to retrieve it. For
    the initial document, that reference is the SD-JWT VC's vct value. For a
    parent document, that reference is the immediate child's extends value.


Thank you, that text works pretty nicely, I think. I've massaged it just a bit in this PR #429